### PR TITLE
feat(workspace): Output-first Workspace + runId SSE + candidate resume

### DIFF
--- a/src/app/api/runs/[id]/resume/route.ts
+++ b/src/app/api/runs/[id]/resume/route.ts
@@ -1,4 +1,4 @@
-import { postResume } from "../../../../server/api/runs/resume";
+import { postResume } from "@/server/api/runs/resume";
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   return postResume(req, { id: params.id });

--- a/src/app/api/runs/start/route.ts
+++ b/src/app/api/runs/start/route.ts
@@ -1,5 +1,6 @@
-import { postStart } from "../../../server/api/runs/start";
+import { postStart } from "@/server/api/runs/start";
 
 export async function POST(req: Request) {
   return postStart(req);
 }
+

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -6,6 +6,7 @@ import ChatMessage from "@/ui/components/ChatMessage";
 import RightPanel from "@/ui/components/RightPanel";
 
 type Msg = { id: string; role: "user" | "assistant" | "system" | "tool"; content: string };
+type Candidate = { id: string; title: string; novelty?: number; risk?: number };
 
 export default function WorkspacePage() {
   const [messages, setMessages] = useState<Msg[]>([
@@ -13,11 +14,15 @@ export default function WorkspacePage() {
   ]);
   const [activity, setActivity] = useState<string[]>([]);
   const [running, setRunning] = useState(false);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
 
   async function onSend(text: string) {
     const id = "u" + Date.now();
     setMessages((m) => [...m, { id, role: "user", content: text }]);
     setRunning(true);
+    setCandidates([]);
+    setRunId(null);
     const res = await fetch("/api/runs/start", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -44,9 +49,11 @@ export default function WorkspacePage() {
         const json = f.slice(6);
         try {
           const msg = JSON.parse(json) as any;
+          if (msg.type === "started" && msg.runId) setRunId(msg.runId);
           if (msg.type === "progress") setActivity((a) => [msg.message, ...a]);
           if (msg.type === "candidates") {
             assistantBuffer += `Top candidates (sample)\n`;
+            setCandidates(msg.items || []);
             for (const c of msg.items) assistantBuffer += `• ${c.title}\n`;
           }
           if (msg.type === "suspend") {
@@ -57,6 +64,33 @@ export default function WorkspacePage() {
         } catch {}
       }
     }
+  }
+
+  async function onSelectCandidate(c: Candidate) {
+    if (!runId) return;
+    setActivity((a) => [
+      `resuming with candidate: ${c.title}`,
+      ...a,
+    ]);
+    const res = await fetch(`/api/runs/${runId}/resume`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ answers: { selected: c } }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+      setActivity((a) => [
+        `resume error: ${data?.error || res.statusText}`,
+        ...a,
+      ]);
+      return;
+    }
+    setMessages((m) => [
+      ...m,
+      { id: "a" + Date.now(), role: "assistant", content: `Acknowledged. Proceeding with: "${c.title}"\nStatus: ${data?.status}` },
+    ]);
+    // Clear candidates after selection
+    setCandidates([]);
   }
 
   const left = useMemo(
@@ -74,7 +108,38 @@ export default function WorkspacePage() {
     [messages, running]
   );
 
-  const right = <RightPanel activity={<ul className="text-sm grid gap-2">{activity.map((l, i) => <li key={i}>• {l}</li>)}</ul>} />;
+  const lastAssistant = useMemo(() => {
+    const as = messages.filter((m) => m.role === "assistant");
+    return as.length ? as[as.length - 1].content : "";
+  }, [messages]);
+
+  const right = (
+    <RightPanel
+      output={
+        candidates.length ? (
+          <div className="grid gap-3">
+            <div className="text-sm text-foreground/80">Select a candidate to continue:</div>
+            <ul className="grid gap-2">
+              {candidates.map((c) => (
+                <li key={c.id} className="border border-white/15 rounded-lg p-3 bg-black/30">
+                  <div className="text-sm font-medium">{c.title}</div>
+                  <div className="mt-2 flex gap-2">
+                    <button onClick={() => onSelectCandidate(c)} className="px-3 py-1 text-sm rounded-md border border-white/20 hover:bg-white/10">Select</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : lastAssistant ? (
+          <div className="text-sm whitespace-pre-wrap leading-relaxed">{lastAssistant}</div>
+        ) : (
+          <div className="text-sm text-foreground/60">No output yet.</div>
+        )
+      }
+      activity={<ul className="text-sm grid gap-2">{activity.map((l, i) => <li key={i}>• {l}</li>)}</ul>}
+      thinking={<div className="text-sm text-foreground/60">Reserved for agent thinking.</div>}
+    />
+  );
 
   return (
     <section className="grid gap-4">
@@ -83,4 +148,3 @@ export default function WorkspacePage() {
     </section>
   );
 }
-

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+import { useMemo, useState } from "react";
+import ChatLayout from "@/ui/components/ChatLayout";
+import ChatInput from "@/ui/components/ChatInput";
+import ChatMessage from "@/ui/components/ChatMessage";
+import RightPanel from "@/ui/components/RightPanel";
+
+type Msg = { id: string; role: "user" | "assistant" | "system" | "tool"; content: string };
+
+export default function WorkspacePage() {
+  const [messages, setMessages] = useState<Msg[]>([
+    { id: "m0", role: "assistant", content: "Hi! Share a domain/keywords to explore research themes." },
+  ]);
+  const [activity, setActivity] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+
+  async function onSend(text: string) {
+    const id = "u" + Date.now();
+    setMessages((m) => [...m, { id, role: "user", content: text }]);
+    setRunning(true);
+    const res = await fetch("/api/runs/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ kind: "theme", input: { query: text } }),
+    });
+    if (!res.ok || !res.body) {
+      setActivity((a) => ["error: failed to start run", ...a]);
+      setRunning(false);
+      return;
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let assistantBuffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split("\n\n");
+      buffer = frames.pop() || "";
+      for (const f of frames) {
+        if (f.startsWith(":")) continue;
+        if (!f.startsWith("data: ")) continue;
+        const json = f.slice(6);
+        try {
+          const msg = JSON.parse(json) as any;
+          if (msg.type === "progress") setActivity((a) => [msg.message, ...a]);
+          if (msg.type === "candidates") {
+            assistantBuffer += `Top candidates (sample)\n`;
+            for (const c of msg.items) assistantBuffer += `• ${c.title}\n`;
+          }
+          if (msg.type === "suspend") {
+            setMessages((m) => [...m, { id: "a" + Date.now(), role: "assistant", content: assistantBuffer || "Done." }]);
+            assistantBuffer = "";
+            setRunning(false);
+          }
+        } catch {}
+      }
+    }
+  }
+
+  const left = useMemo(
+    () => (
+      <div className="grid gap-4">
+        <div className="grid gap-3">
+          {messages.map((m) => (
+            <ChatMessage key={m.id} role={m.role} content={m.content} />
+          ))}
+        </div>
+        <ChatInput onSend={onSend} />
+        {running && <div className="text-xs text-foreground/60">Running…</div>}
+      </div>
+    ),
+    [messages, running]
+  );
+
+  const right = <RightPanel activity={<ul className="text-sm grid gap-2">{activity.map((l, i) => <li key={i}>• {l}</li>)}</ul>} />;
+
+  return (
+    <section className="grid gap-4">
+      <h1 className="text-2xl font-semibold">Workspace</h1>
+      <ChatLayout left={left} right={right} />
+    </section>
+  );
+}
+

--- a/src/server/api/runs/start.ts
+++ b/src/server/api/runs/start.ts
@@ -13,8 +13,9 @@ export async function postStart(req: Request): Promise<Response> {
       async start(controller) {
         const send = (obj: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
         const ping = () => controller.enqueue(encoder.encode(":\n\n"));
+        const runId = `run_${Math.random().toString(36).slice(2, 9)}`;
 
-        send({ type: "started", at: Date.now(), input });
+        send({ type: "started", at: Date.now(), input, runId });
         ping();
         await new Promise((r) => setTimeout(r, 200));
         send({ type: "progress", message: "fetching papers..." });
@@ -28,8 +29,9 @@ export async function postStart(req: Request): Promise<Response> {
             { id: "t2", title: "Stablecoin shocks and DeFi liquidity", novelty: 0.8, risk: 0.5 },
             { id: "t3", title: "RLHF data leakage in academic benchmarks", novelty: 0.6, risk: 0.4 },
           ],
+          runId,
         });
-        send({ type: "suspend", reason: "select_candidate" });
+        send({ type: "suspend", reason: "select_candidate", runId });
         controller.close();
       },
     });

--- a/src/ui/components/ChatInput.tsx
+++ b/src/ui/components/ChatInput.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useState } from "react";
+
+export default function ChatInput({ onSend }: { onSend: (text: string) => void }) {
+  const [text, setText] = useState("");
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const t = text.trim();
+        if (!t) return;
+        onSend(t);
+        setText("");
+      }}
+      className="flex items-center gap-2 border border-white/15 bg-black/30 rounded-xl p-2"
+    >
+      <textarea
+        className="flex-1 bg-transparent outline-none resize-none min-h-10 max-h-40"
+        placeholder="Send a message..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="rounded-md border border-white/20 px-3 py-2 text-sm hover:bg-white/10"
+      >
+        Send
+      </button>
+    </form>
+  );
+}
+

--- a/src/ui/components/ChatLayout.tsx
+++ b/src/ui/components/ChatLayout.tsx
@@ -1,9 +1,8 @@
 export default function ChatLayout({ left, right }: { left: React.ReactNode; right: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_380px] gap-6">
+    <div className="grid grid-cols-1 lg:grid-cols-[380px_minmax(0,1fr)] gap-6">
       <div className="grid gap-4">{left}</div>
       <div className="grid gap-4">{right}</div>
     </div>
   );
 }
-

--- a/src/ui/components/ChatLayout.tsx
+++ b/src/ui/components/ChatLayout.tsx
@@ -1,0 +1,9 @@
+export default function ChatLayout({ left, right }: { left: React.ReactNode; right: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_380px] gap-6">
+      <div className="grid gap-4">{left}</div>
+      <div className="grid gap-4">{right}</div>
+    </div>
+  );
+}
+

--- a/src/ui/components/ChatMessage.tsx
+++ b/src/ui/components/ChatMessage.tsx
@@ -1,0 +1,33 @@
+type Props = {
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+};
+
+export default function ChatMessage({ role, content }: Props) {
+  const isUser = role === "user";
+  const isAssistant = role === "assistant";
+  const bubble = (
+    <div
+      className={
+        (isUser
+          ? "bg-white/10 border-white/20"
+          : "bg-black/40 border-white/15") +
+        " border rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap"
+      }
+    >
+      {content}
+    </div>
+  );
+  return (
+    <div className={"flex gap-2 items-start " + (isUser ? "justify-end" : "justify-start")}> 
+      {!isUser && (
+        <div className="w-7 h-7 rounded-full bg-white/10 border border-white/15 grid place-items-center select-none">🤖</div>
+      )}
+      {bubble}
+      {isUser && (
+        <div className="w-7 h-7 rounded-full bg-white/10 border border-white/15 grid place-items-center select-none">🙂</div>
+      )}
+    </div>
+  );
+}
+

--- a/src/ui/components/Header.tsx
+++ b/src/ui/components/Header.tsx
@@ -16,6 +16,7 @@ export default function Header() {
           <Link href="/" className="font-semibold tracking-tight">vibeResearch</Link>
           <nav className="hidden sm:flex items-center gap-3 text-sm text-foreground/80">
             <Link href="/" className="hover:underline">Home</Link>
+            <Link href="/workspace" className="hover:underline">Workspace</Link>
             <Link href="/theme" className="hover:underline">Theme</Link>
             <Link href="/plan" className="hover:underline">Plan</Link>
             <Link href="/export" className="hover:underline">Export</Link>

--- a/src/ui/components/RightPanel.tsx
+++ b/src/ui/components/RightPanel.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useState } from "react";
+
+export default function RightPanel({ output, activity, thinking }: { output?: React.ReactNode; activity?: React.ReactNode; thinking?: React.ReactNode }) {
+  const [tab, setTab] = useState<"output" | "activity" | "thinking">("output");
+  const tabs: { key: typeof tab; label: string }[] = [
+    { key: "output", label: "Output" },
+    { key: "activity", label: "Activity" },
+    { key: "thinking", label: "Thinking" },
+  ];
+  return (
+    <aside className="border-l border-white/10 pl-4">
+      <div className="flex items-center gap-2 mb-3">
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`px-3 py-1 rounded-md text-sm border ${tab === t.key ? "bg-white/10 border-white/20" : "border-white/10 hover:bg-white/5"}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-[300px]">
+        {tab === "output" && (output || <div className="text-sm text-foreground/60">No output yet.</div>)}
+        {tab === "activity" && (activity || <div className="text-sm text-foreground/60">No activity yet.</div>)}
+        {tab === "thinking" && (thinking || <div className="text-sm text-foreground/60">No thinking yet.</div>)}
+      </div>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
Summary\n- Make right Output/Activity/Thinking panel primary; compact left chat column.\n- Include runId in SSE events (started/candidates/suspend).\n- Render selectable candidates in Output; POST /api/runs/{runId}/resume on selection; append assistant confirmation.\n- Wire Next.js app routes for /api/runs/start and /api/runs/[id]/resume.\n\nScope\n- UI: ChatLayout width swap, Output-first Workspace refinements.\n- API: route wrappers delegating to server handlers.\n- SSE: add runId to events.\n- Resume: minimal client-side wiring (server still stub).\n\nAcceptance\n- /workspace shows Activity streaming and candidates; selecting a candidate calls resume and shows confirmation.\n- TypeScript build passes.\n\nTesting\n- npm run dev → /workspace → send prompt → observe Activity and candidates → Select.\n\nCloses #37