### PR TITLE
feat(theme): candidate selection → resume draft plan (Workspace + Theme)

### DIFF
--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -7,6 +7,16 @@ import RightPanel from "@/ui/components/RightPanel";
 
 type Msg = { id: string; role: "user" | "assistant" | "system" | "tool"; content: string };
 type Candidate = { id: string; title: string; novelty?: number; risk?: number };
+type Plan = {
+  title: string;
+  rq: string;
+  hypothesis: string;
+  data: string;
+  methods: string;
+  identification: string;
+  validation: string;
+  ethics: string;
+};
 
 export default function WorkspacePage() {
   const [messages, setMessages] = useState<Msg[]>([
@@ -16,6 +26,7 @@ export default function WorkspacePage() {
   const [running, setRunning] = useState(false);
   const [runId, setRunId] = useState<string | null>(null);
   const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [plan, setPlan] = useState<Plan | null>(null);
 
   async function onSend(text: string) {
     const id = "u" + Date.now();
@@ -91,6 +102,7 @@ export default function WorkspacePage() {
     ]);
     // Clear candidates after selection
     setCandidates([]);
+    if (data?.plan) setPlan(data.plan as Plan);
   }
 
   const left = useMemo(
@@ -116,7 +128,21 @@ export default function WorkspacePage() {
   const right = (
     <RightPanel
       output={
-        candidates.length ? (
+        plan ? (
+          <div className="grid gap-3">
+            <div className="text-base font-medium">Draft Research Plan</div>
+            <div className="text-sm"><span className="font-medium">Title:</span> {plan.title}</div>
+            <ul className="text-sm grid gap-2">
+              <li><span className="font-medium">RQ:</span> {plan.rq}</li>
+              <li><span className="font-medium">Hypothesis:</span> {plan.hypothesis}</li>
+              <li><span className="font-medium">Data:</span> {plan.data}</li>
+              <li><span className="font-medium">Methods:</span> {plan.methods}</li>
+              <li><span className="font-medium">Identification:</span> {plan.identification}</li>
+              <li><span className="font-medium">Validation:</span> {plan.validation}</li>
+              <li><span className="font-medium">Ethics:</span> {plan.ethics}</li>
+            </ul>
+          </div>
+        ) : candidates.length ? (
           <div className="grid gap-3">
             <div className="text-sm text-foreground/80">Select a candidate to continue:</div>
             <ul className="grid gap-2">

--- a/src/server/api/runs/resume.ts
+++ b/src/server/api/runs/resume.ts
@@ -3,15 +3,27 @@ export async function postResume(req: Request, params: { id: string }): Promise<
   try {
     const { id } = params;
     const body = await req.json().catch(() => ({}));
-    const answers = body?.answers ?? null;
+    const selected = body?.answers?.selected ?? null;
 
-    // TODO: resume Mastra run with provided answers
+    // Minimal draft plan generation (stub). Replace with Mastra workflow later.
+    const title: string = selected?.title || "Selected Theme";
+    const plan = {
+      title,
+      rq: `What is the impact/effect of ${title.toLowerCase()}?`,
+      hypothesis: `We hypothesize ${title.toLowerCase()} yields measurable improvements with trade-offs.`,
+      data: "Outline target datasets/sources (public stats, platform logs, paper corpora)",
+      methods: "Candidate methods: descriptive, DiD, IV, synthetic control, ablation/robustness",
+      identification: "Assumptions and threats; proxies; instruments; falsification checks",
+      validation: "Holdout evaluation; sensitivity; placebo; external benchmark",
+      ethics: "Bias, privacy, consent, misuse considerations; mitigation steps",
+    };
+
     const payload = {
       ok: true,
-      status: "not_implemented",
-      message: "run resumed (stub)",
+      status: "resumed",
       id,
-      answers,
+      plan,
+      selected,
     };
     return new Response(JSON.stringify(payload), { headers: contentType, status: 200 });
   } catch (err: any) {
@@ -21,4 +33,3 @@ export async function postResume(req: Request, params: { id: string }): Promise<
     );
   }
 }
-


### PR DESCRIPTION
## Summary

This PR completes the first end-to-end suspend/resume loop for the Theme Exploration MVP:
- Adds a minimal server-side resume stub that returns a structured Draft Research Plan.
- Enables candidate selection on the Theme page to call resume.
- Shows the structured plan in the Workspace Output and on Theme.

## Scope

- API
  - `POST /api/runs/[id]/resume`: returns `{ plan, selected, status }` (stub until Mastra).
- UI
  - Theme (`/theme`): candidate cards now include a Select button; after resume, a draft plan is rendered.
  - Workspace (`/workspace`): Output tab renders a structured plan after resume; retains Activity/Thinking.
- SSE
  - No protocol change here; runId is already present from earlier work.

## Acceptance

- Start a run from `/workspace` or `/theme`.
- See progress + candidates.
- Click Select on a candidate → resume returns a draft plan → plan appears in Output.
- TypeScript passes.

## Notes

- The resume implementation is a stub; Mastra integration will replace the plan generation.
- Next PRs will persist runs/candidates to Supabase and add comparison UI.

## Linked Issues

- Closes #11 (Suspend/Resume flow)
- Closes #10 (Theme Explorer page UI: selection/continue)
