### PR TITLE
feat(api): persist runs + candidates to Supabase; list runs

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -80,5 +80,14 @@ create table if not exists results (
   created_at timestamptz not null default now()
 );
 
--- RLS policies are to be added in Supabase (not included here).
+-- Theme exploration: candidates proposed during a run
+create table if not exists run_candidates (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references runs(id) on delete cascade,
+  title text not null,
+  novelty numeric,
+  risk numeric,
+  created_at timestamptz not null default now()
+);
 
+-- RLS policies are to be added in Supabase (not included here).

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,0 +1,12 @@
+export async function GET() {
+  const { supabaseServerClient } = await import("@/lib/supabase/server");
+  const sb = supabaseServerClient();
+  if (!sb) return Response.json({ ok: true, items: [], note: "Supabase not configured" });
+  const { data, error } = await sb
+    .from("runs")
+    .select("id, project_id, kind, status, started_at, ended_at")
+    .order("started_at", { ascending: false });
+  if (error) return Response.json({ ok: false, error: error.message }, { status: 500 });
+  return Response.json({ ok: true, items: data });
+}
+

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -78,3 +78,11 @@ export interface Result {
   created_at: string; // ISO8601
 }
 
+export interface RunCandidate {
+  id: ID;
+  run_id: ID;
+  title: string;
+  novelty?: number;
+  risk?: number;
+  created_at?: string; // ISO8601
+}

--- a/src/server/api/runs/resume.ts
+++ b/src/server/api/runs/resume.ts
@@ -18,6 +18,19 @@ export async function postResume(req: Request, params: { id: string }): Promise<
       ethics: "Bias, privacy, consent, misuse considerations; mitigation steps",
     };
 
+    // If id is a DB run id (uuid), try to update status to running/resumed
+    try {
+      const { supabaseServerClient } = await import("@/lib/supabase/server");
+      const sb = supabaseServerClient();
+      if (sb) {
+        await sb.from("runs").update({ status: "running" }).eq("id", id);
+        // Optionally, store a simple result payload
+        // await sb.from("results").insert({ project_id: ..., run_id: id, type: 'plan', uri: 'inline', meta_json: plan });
+      }
+    } catch {
+      // ignore persistence errors
+    }
+
     const payload = {
       ok: true,
       status: "resumed",

--- a/src/server/api/runs/start.ts
+++ b/src/server/api/runs/start.ts
@@ -13,7 +13,20 @@ export async function postStart(req: Request): Promise<Response> {
       async start(controller) {
         const send = (obj: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
         const ping = () => controller.enqueue(encoder.encode(":\n\n"));
-        const runId = `run_${Math.random().toString(36).slice(2, 9)}`;
+        // Optional persistence via Supabase when configured and projectId provided
+        const { supabaseServerClient } = await import("@/lib/supabase/server");
+        const sb = supabaseServerClient();
+        const projectId: string | null = (input as any)?.projectId ?? null;
+        let dbRunId: string | null = null;
+        if (sb && projectId) {
+          const { data, error } = await sb
+            .from("runs")
+            .insert({ project_id: projectId, kind: "theme", status: "running", started_at: new Date().toISOString() })
+            .select("id")
+            .single();
+          if (!error && data?.id) dbRunId = data.id as string;
+        }
+        const runId = dbRunId ?? `run_${Math.random().toString(36).slice(2, 9)}`;
 
         send({ type: "started", at: Date.now(), input, runId });
         ping();
@@ -22,15 +35,22 @@ export async function postStart(req: Request): Promise<Response> {
         await new Promise((r) => setTimeout(r, 300));
         send({ type: "progress", message: "ranking candidates..." });
         await new Promise((r) => setTimeout(r, 300));
-        send({
-          type: "candidates",
-          items: [
-            { id: "t1", title: "Impact of LLM adoption on SME productivity", novelty: 0.7, risk: 0.3 },
-            { id: "t2", title: "Stablecoin shocks and DeFi liquidity", novelty: 0.8, risk: 0.5 },
-            { id: "t3", title: "RLHF data leakage in academic benchmarks", novelty: 0.6, risk: 0.4 },
-          ],
-          runId,
-        });
+        const candidates = [
+          { id: "t1", title: "Impact of LLM adoption on SME productivity", novelty: 0.7, risk: 0.3 },
+          { id: "t2", title: "Stablecoin shocks and DeFi liquidity", novelty: 0.8, risk: 0.5 },
+          { id: "t3", title: "RLHF data leakage in academic benchmarks", novelty: 0.6, risk: 0.4 },
+        ];
+        // Persist candidates if possible
+        if (sb && dbRunId) {
+          await sb.from("run_candidates").insert(
+            candidates.map((c) => ({ run_id: dbRunId, title: c.title, novelty: c.novelty, risk: c.risk }))
+          );
+        }
+        send({ type: "candidates", items: candidates, runId });
+        // Update run status to suspended if persisted
+        if (sb && dbRunId) {
+          await sb.from("runs").update({ status: "suspended" }).eq("id", dbRunId);
+        }
         send({ type: "suspend", reason: "select_candidate", runId });
         controller.close();
       },


### PR DESCRIPTION
## Summary

Persist Theme Exploration runs and their candidate items to Supabase when configured, while gracefully degrading to no-op when env vars are missing. Also add a minimal `GET /api/runs` for listing.

## Scope

- Start
  - `POST /api/runs/start` now optionally creates a `runs` row (status=running) when `input.projectId` is provided.
  - Emits `runId` as the DB run id when persisted; falls back to ephemeral id otherwise.
  - Persists `run_candidates` for streamed candidates.
  - Updates run status to `suspended` at suspend.
- Resume
  - `POST /api/runs/{id}/resume` updates run status to `running` (stub until full workflow).
- List
  - `GET /api/runs` returns latest runs (id, project_id, kind, status, started/ended).
- Docs/Types
  - docs/db/schema.sql: add `run_candidates` table.
  - src/db/types.ts: add `RunCandidate` interface.

## Acceptance

- With Supabase configured and a valid `projectId`:
  - Start from `/workspace` or `/theme` (can be extended to pass projectId later) → a `runs` row is created.
  - Candidates appear and are inserted into `run_candidates`.
  - On suspend, run becomes `suspended`.
  - On resume, run becomes `running`.
- Without Supabase config: behavior remains unchanged; persistence is skipped.

## Notes

- UI does not yet pass `projectId`; persistence kicks in once `input.projectId` is provided.
- Mastra integration will replace the stub resume logic and likely write plan/results.

## Linked Issues

- Closes #12
