### PR TITLE
feat(api/docs): secure persistence pass — results on resume, project-scoped runs, RLS docs

### DIFF
--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,12 +1,12 @@
-export async function GET() {
+export async function GET(req: Request) {
   const { supabaseServerClient } = await import("@/lib/supabase/server");
   const sb = supabaseServerClient();
   if (!sb) return Response.json({ ok: true, items: [], note: "Supabase not configured" });
-  const { data, error } = await sb
-    .from("runs")
-    .select("id, project_id, kind, status, started_at, ended_at")
-    .order("started_at", { ascending: false });
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get("projectId");
+  let query = sb.from("runs").select("id, project_id, kind, status, started_at, ended_at").order("started_at", { ascending: false });
+  if (projectId) query = query.eq("project_id", projectId);
+  const { data, error } = await query;
   if (error) return Response.json({ ok: false, error: error.message }, { status: 500 });
   return Response.json({ ok: true, items: data });
 }
-


### PR DESCRIPTION
## Summary

Strengthen persistence and take a first step toward secure usage of Supabase:
- Save draft plan to `results` on resume (inline meta for now).
- Add `projectId` filter to `GET /api/runs` to scope listings.
- Document RLS policies and ownership model in `docs/db/schema.sql`.

## Scope

- Resume
  - Update `runs` status to `running`; insert a `results` row (`type=plan`, `uri=inline:plan`, `meta_json=plan`).
- List
  - Support `GET /api/runs?projectId=...` to narrow to a project.
- Security Docs
  - Enable RLS and add policies for `projects`, `runs`, `run_candidates`, `results` (owner via `auth.uid()` + joins).
  - Notes: Service Role bypasses RLS; endpoints must be treated as trusted server-only.

## Acceptance

- Resume returns unchanged API shape, but a corresponding `results` row is created (when configured).
- `GET /api/runs?projectId=<id>` lists only runs for that project.
- RLS policies are defined and ready to apply in Supabase.

## Notes

- We intentionally did not add dependencies; a future PR will integrate auth helpers to enforce user context in server routes (so we can avoid Service Role or add user-bound checks).
- `results` currently stores plan inline; this will evolve into structured plan storage or Markdown/CSL artifacts.

## Linked Issues

- Progress toward EPIC-103 (Auth & Persistence) and EPIC-106 (Observability)
