### PR TITLE
chore(db): add Supabase scripts + type generation

### DIFF
--- a/docs/db/overview.md
+++ b/docs/db/overview.md
@@ -1,0 +1,12 @@
+DB workflow overview
+
+- Source of truth: SQL migrations in `supabase/migrations/*.sql`.
+- Local dev: run `supabase start` (Docker) then `supabase db reset` to apply migrations and `supabase/seed.sql`.
+- Type generation: `cd frontend && bun run db:types` to generate `src/db/types.supabase.ts` from the local DB.
+- Remote sync: `supabase db push` from repo root to apply your migrations to the remote project when ready.
+
+Notes
+- Do not edit schema solely in `docs/`; capture changes as migrations under `supabase/migrations/`.
+- RLS uses `auth.uid()`; insert rows with the current authenticated user to pass policies.
+- Seeds run with elevated privileges during `db reset` and bypass RLS.
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "db:start": "cd .. && supabase start",
+    "db:stop": "cd .. && supabase stop",
+    "db:reset": "cd .. && supabase db reset",
+    "db:types": "cd .. && supabase gen types typescript --local > frontend/src/db/types.supabase.ts"
   },
   "dependencies": {
     "zod": "^3.23.8",


### PR DESCRIPTION
This PR adds minimal developer ergonomics for the new Supabase-local setup.\n\n- frontend/package.json: db:start, db:stop, db:reset, db:types scripts\n- docs/db/overview.md: migration-first workflow, local/remote flow, RLS notes\n\nFollow-ups (optional):\n- Generate types via `bun run db:types` after `supabase start`\n- Switch app imports to generated types as needed