### PR TITLE
feat(runs): SSE wiring + agent/workflow skeletons

### DIFF
--- a/frontend/src/agents/theme-finder.ts
+++ b/frontend/src/agents/theme-finder.ts
@@ -1,0 +1,42 @@
+export type ThemeFinderInput = {
+  query?: string;
+  domain?: string;
+  keywords?: string;
+  projectId?: string;
+};
+
+export type ThemeCandidate = {
+  id: string;
+  title: string;
+  novelty: number;
+  risk: number;
+};
+
+export type ThemeFinderEvents =
+  | { type: "started"; at: number; input: ThemeFinderInput; runId: string }
+  | { type: "progress"; message: string }
+  | { type: "candidates"; items: ThemeCandidate[]; runId: string }
+  | { type: "suspend"; reason: "select_candidate"; runId: string };
+
+export class ThemeFinderAgent {
+  // In the future, replace internals with Mastra agent and .suspend()
+  constructor(private readonly opts: { maxSteps?: number } = {}) {}
+
+  async run(input: ThemeFinderInput, emit: (e: ThemeFinderEvents) => Promise<void> | void) {
+    const runId = `run_${Math.random().toString(36).slice(2, 9)}`;
+    await emit({ type: "started", at: Date.now(), input, runId });
+    await emit({ type: "progress", message: "fetching papers..." });
+    await new Promise((r) => setTimeout(r, 200));
+    await emit({ type: "progress", message: "ranking candidates..." });
+    await new Promise((r) => setTimeout(r, 250));
+    const candidates: ThemeCandidate[] = [
+      { id: "t1", title: "Impact of LLM adoption on SME productivity", novelty: 0.7, risk: 0.3 },
+      { id: "t2", title: "Stablecoin shocks and DeFi liquidity", novelty: 0.8, risk: 0.5 },
+      { id: "t3", title: "RLHF data leakage in academic benchmarks", novelty: 0.6, risk: 0.4 },
+    ];
+    await emit({ type: "candidates", items: candidates, runId });
+    await emit({ type: "suspend", reason: "select_candidate", runId });
+    return { runId, candidates };
+  }
+}
+

--- a/frontend/src/db/types.supabase.ts
+++ b/frontend/src/db/types.supabase.ts
@@ -1,0 +1,603 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          operationName?: string
+          query?: string
+          variables?: Json
+          extensions?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      chunks: {
+        Row: {
+          content: string
+          created_at: string
+          document_id: string
+          embedding: string | null
+          id: string
+          idx: number
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          document_id: string
+          embedding?: string | null
+          id?: string
+          idx?: number
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          document_id?: string
+          embedding?: string | null
+          id?: string
+          idx?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chunks_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      citations: {
+        Row: {
+          created_at: string
+          document_id: string | null
+          id: string
+          meta: Json
+        }
+        Insert: {
+          created_at?: string
+          document_id?: string | null
+          id?: string
+          meta?: Json
+        }
+        Update: {
+          created_at?: string
+          document_id?: string | null
+          id?: string
+          meta?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "citations_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      documents: {
+        Row: {
+          created_at: string
+          id: string
+          metadata: Json | null
+          project_id: string
+          source_url: string | null
+          title: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          project_id: string
+          source_url?: string | null
+          title?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          project_id?: string
+          source_url?: string | null
+          title?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "documents_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      plans: {
+        Row: {
+          content: Json
+          created_at: string
+          id: string
+          project_id: string
+          status: string | null
+          title: string | null
+        }
+        Insert: {
+          content?: Json
+          created_at?: string
+          id?: string
+          project_id: string
+          status?: string | null
+          title?: string | null
+        }
+        Update: {
+          content?: Json
+          created_at?: string
+          id?: string
+          project_id?: string
+          status?: string | null
+          title?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "plans_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      projects: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          name: string
+          owner_id: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          name: string
+          owner_id: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          name?: string
+          owner_id?: string
+        }
+        Relationships: []
+      }
+      results: {
+        Row: {
+          content: Json
+          created_at: string
+          id: string
+          run_id: string
+        }
+        Insert: {
+          content?: Json
+          created_at?: string
+          id?: string
+          run_id: string
+        }
+        Update: {
+          content?: Json
+          created_at?: string
+          id?: string
+          run_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "results_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "runs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      runs: {
+        Row: {
+          finished_at: string | null
+          id: string
+          kind: string
+          project_id: string
+          started_at: string
+          status: string
+        }
+        Insert: {
+          finished_at?: string | null
+          id?: string
+          kind: string
+          project_id: string
+          started_at?: string
+          status?: string
+        }
+        Update: {
+          finished_at?: string | null
+          id?: string
+          kind?: string
+          project_id?: string
+          started_at?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "runs_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tool_invocations: {
+        Row: {
+          args: Json
+          cost_usd: number | null
+          created_at: string
+          id: string
+          result: Json | null
+          run_id: string
+          tool: string
+        }
+        Insert: {
+          args?: Json
+          cost_usd?: number | null
+          created_at?: string
+          id?: string
+          result?: Json | null
+          run_id: string
+          tool: string
+        }
+        Update: {
+          args?: Json
+          cost_usd?: number | null
+          created_at?: string
+          id?: string
+          result?: Json | null
+          run_id?: string
+          tool?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tool_invocations_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "runs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      binary_quantize:
+        | {
+            Args: {
+              "": string
+            }
+            Returns: unknown
+          }
+        | {
+            Args: {
+              "": unknown
+            }
+            Returns: unknown
+          }
+      halfvec_avg: {
+        Args: {
+          "": number[]
+        }
+        Returns: unknown
+      }
+      halfvec_out: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      halfvec_send: {
+        Args: {
+          "": unknown
+        }
+        Returns: string
+      }
+      halfvec_typmod_in: {
+        Args: {
+          "": unknown[]
+        }
+        Returns: number
+      }
+      hnsw_bit_support: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      hnsw_halfvec_support: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      hnsw_sparsevec_support: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      hnswhandler: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      is_project_owner: {
+        Args: {
+          p_project_id: string
+        }
+        Returns: boolean
+      }
+      ivfflat_bit_support: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      ivfflat_halfvec_support: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      ivfflathandler: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      l2_norm:
+        | {
+            Args: {
+              "": unknown
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              "": unknown
+            }
+            Returns: number
+          }
+      l2_normalize:
+        | {
+            Args: {
+              "": string
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              "": unknown
+            }
+            Returns: unknown
+          }
+        | {
+            Args: {
+              "": unknown
+            }
+            Returns: unknown
+          }
+      sparsevec_out: {
+        Args: {
+          "": unknown
+        }
+        Returns: unknown
+      }
+      sparsevec_send: {
+        Args: {
+          "": unknown
+        }
+        Returns: string
+      }
+      sparsevec_typmod_in: {
+        Args: {
+          "": unknown[]
+        }
+        Returns: number
+      }
+      vector_avg: {
+        Args: {
+          "": number[]
+        }
+        Returns: string
+      }
+      vector_dims:
+        | {
+            Args: {
+              "": string
+            }
+            Returns: number
+          }
+        | {
+            Args: {
+              "": unknown
+            }
+            Returns: number
+          }
+      vector_norm: {
+        Args: {
+          "": string
+        }
+        Returns: number
+      }
+      vector_out: {
+        Args: {
+          "": string
+        }
+        Returns: unknown
+      }
+      vector_send: {
+        Args: {
+          "": string
+        }
+        Returns: string
+      }
+      vector_typmod_in: {
+        Args: {
+          "": unknown[]
+        }
+        Returns: number
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DefaultSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const
+

--- a/frontend/src/server/api/runs/resume.ts
+++ b/frontend/src/server/api/runs/resume.ts
@@ -1,60 +1,65 @@
+import type { ThemeCandidate } from "@/agents/theme-finder";
+import { draftPlanFromSelection } from "@/workflows/research-plan";
+
 type Ctx = { sb?: any };
 export async function postResume(req: Request, params: { id: string }, ctx: Ctx = {}): Promise<Response> {
-  const contentType = { "content-type": "application/json" };
   try {
     const { id } = params;
     const { z } = await import("zod");
     const schema = z.object({ answers: z.object({ selected: z.object({ id: z.string(), title: z.string() }).optional() }).optional() });
     const parsed = schema.safeParse(await req.json().catch(() => ({})));
-    if (!parsed.success) return new Response(JSON.stringify({ ok: false, error: "invalid_payload" }), { headers: contentType, status: 400 });
-    const body = parsed.data as any;
-    const selected = body?.answers?.selected ?? null;
-
-    // Minimal draft plan generation (stub). Replace with Mastra workflow later.
-    const title: string = selected?.title || "Selected Theme";
-    const plan = {
-      title,
-      rq: `What is the impact/effect of ${title.toLowerCase()}?`,
-      hypothesis: `We hypothesize ${title.toLowerCase()} yields measurable improvements with trade-offs.`,
-      data: "Outline target datasets/sources (public stats, platform logs, paper corpora)",
-      methods: "Candidate methods: descriptive, DiD, IV, synthetic control, ablation/robustness",
-      identification: "Assumptions and threats; proxies; instruments; falsification checks",
-      validation: "Holdout evaluation; sensitivity; placebo; external benchmark",
-      ethics: "Bias, privacy, consent, misuse considerations; mitigation steps",
-    };
-
-    // If id is a DB run id (uuid), try to update status to running/resumed
-    try {
-      const sb = ctx.sb ?? null;
-      if (sb) {
-        // Update run status and fetch project_id for results
-        const { data: runRow } = await sb.from("runs").update({ status: "running" }).eq("id", id).select("id,project_id").single();
-        if (runRow?.project_id) {
-          await sb.from("results").insert({
-            project_id: runRow.project_id,
-            run_id: id,
-            type: "plan",
-            uri: "inline:plan",
-            meta_json: plan,
-          });
-        }
-      }
-    } catch {
-      // ignore persistence errors
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ ok: false, error: "invalid_payload" }), {
+        headers: { "content-type": "application/json" },
+        status: 400,
+      });
     }
+    const body = parsed.data as any;
+    const selected: ThemeCandidate | null = body?.answers?.selected ?? null;
 
-    const payload = {
-      ok: true,
-      status: "resumed",
-      id,
-      plan,
-      selected,
-    };
-    return new Response(JSON.stringify(payload), { headers: contentType, status: 200 });
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const send = (obj: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
+        const ping = () => controller.enqueue(encoder.encode(":\n\n"));
+
+        // Try to mark run as resumed/running
+        const sb = ctx.sb ?? null;
+        if (sb) {
+          await sb.from("runs").update({ status: "running" }).eq("id", id);
+        }
+
+        const emit = async (e: any) => {
+          await send(e);
+          ping();
+        };
+
+        // Run the workflow and stream progress/final
+        const plan = await draftPlanFromSelection(selected, emit, id);
+
+        // Persist result if possible
+        if (sb) {
+          try {
+            await sb.from("results").insert({ run_id: id, content: plan });
+            await sb.from("runs").update({ status: "completed", finished_at: new Date().toISOString() }).eq("id", id);
+          } catch {}
+        }
+
+        controller.close();
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "content-type": "text/event-stream; charset=utf-8",
+        "cache-control": "no-cache, no-transform",
+        connection: "keep-alive",
+      },
+    });
   } catch (err: any) {
-    return new Response(
-      JSON.stringify({ ok: false, error: err?.message ?? "unknown" }),
-      { headers: { "content-type": "application/json" }, status: 500 }
-    );
+    return new Response(JSON.stringify({ ok: false, error: err?.message ?? "unknown" }), {
+      headers: { "content-type": "application/json" },
+      status: 500,
+    });
   }
 }

--- a/frontend/src/server/api/runs/start.ts
+++ b/frontend/src/server/api/runs/start.ts
@@ -1,3 +1,5 @@
+import { ThemeFinderAgent, type ThemeFinderInput } from "@/agents/theme-finder";
+
 type Ctx = { sb?: any };
 export async function postStart(req: Request, ctx: Ctx = {}): Promise<Response> {
   try {
@@ -33,44 +35,31 @@ export async function postStart(req: Request, ctx: Ctx = {}): Promise<Response> 
       async start(controller) {
         const send = (obj: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
         const ping = () => controller.enqueue(encoder.encode(":\n\n"));
-        // Optional persistence via Supabase when configured and projectId provided
+
         const sb = ctx.sb ?? null;
         const projectId: string | null = (input as any)?.projectId ?? null;
         let dbRunId: string | null = null;
         if (sb && projectId) {
-          const { data, error } = await sb
+          const { data } = await sb
             .from("runs")
             .insert({ project_id: projectId, kind: "theme", status: "running", started_at: new Date().toISOString() })
             .select("id")
             .single();
-          if (!error && data?.id) dbRunId = data.id as string;
+          if (data?.id) dbRunId = data.id as string;
         }
-        const runId = dbRunId ?? `run_${Math.random().toString(36).slice(2, 9)}`;
 
-        send({ type: "started", at: Date.now(), input, runId });
-        ping();
-        await new Promise((r) => setTimeout(r, 200));
-        send({ type: "progress", message: "fetching papers..." });
-        await new Promise((r) => setTimeout(r, 300));
-        send({ type: "progress", message: "ranking candidates..." });
-        await new Promise((r) => setTimeout(r, 300));
-        const candidates = [
-          { id: "t1", title: "Impact of LLM adoption on SME productivity", novelty: 0.7, risk: 0.3 },
-          { id: "t2", title: "Stablecoin shocks and DeFi liquidity", novelty: 0.8, risk: 0.5 },
-          { id: "t3", title: "RLHF data leakage in academic benchmarks", novelty: 0.6, risk: 0.4 },
-        ];
-        // Persist candidates if possible
-        if (sb && dbRunId) {
-          await sb.from("run_candidates").insert(
-            candidates.map((c) => ({ run_id: dbRunId, title: c.title, novelty: c.novelty, risk: c.risk }))
-          );
-        }
-        send({ type: "candidates", items: candidates, runId });
-        // Update run status to suspended if persisted
-        if (sb && dbRunId) {
-          await sb.from("runs").update({ status: "suspended" }).eq("id", dbRunId);
-        }
-        send({ type: "suspend", reason: "select_candidate", runId });
+        const agent = new ThemeFinderAgent({ maxSteps: 8 });
+        const emit = async (e: any) => {
+          // Also persist status transitions if possible
+          if (sb && dbRunId && e?.type === "suspend") {
+            await sb.from("runs").update({ status: "suspended" }).eq("id", dbRunId);
+          }
+          await send(e);
+          ping();
+        };
+
+        // Run agent and stream events
+        await agent.run(input as ThemeFinderInput, emit);
         controller.close();
       },
     });

--- a/frontend/src/workflows/research-plan.ts
+++ b/frontend/src/workflows/research-plan.ts
@@ -1,0 +1,44 @@
+import type { ThemeCandidate } from "@/agents/theme-finder";
+
+export type DraftPlan = {
+  title: string;
+  rq: string;
+  hypothesis: string;
+  data: string;
+  methods: string;
+  identification: string;
+  validation: string;
+  ethics: string;
+};
+
+export type ResumeEvents =
+  | { type: "started"; at: number; runId: string; selected?: ThemeCandidate | null }
+  | { type: "progress"; message: string }
+  | { type: "final"; plan: DraftPlan; selected?: ThemeCandidate | null };
+
+export async function draftPlanFromSelection(
+  selected: ThemeCandidate | null | undefined,
+  emit: (e: ResumeEvents) => Promise<void> | void,
+  runId: string
+) {
+  await emit({ type: "started", at: Date.now(), runId, selected: selected ?? null });
+  await emit({ type: "progress", message: "compiling methods and outline..." });
+  await new Promise((r) => setTimeout(r, 200));
+  await emit({ type: "progress", message: "drafting research questions..." });
+  await new Promise((r) => setTimeout(r, 200));
+
+  const title = selected?.title || "Selected Theme";
+  const plan: DraftPlan = {
+    title,
+    rq: `What is the impact/effect of ${title.toLowerCase()}?`,
+    hypothesis: `We hypothesize ${title.toLowerCase()} yields measurable improvements with trade-offs.`,
+    data: "Outline target datasets/sources (public stats, platform logs, paper corpora)",
+    methods: "Candidate methods: descriptive, DiD, IV, synthetic control, ablation/robustness",
+    identification: "Assumptions and threats; proxies; instruments; falsification checks",
+    validation: "Holdout evaluation; sensitivity; placebo; external benchmark",
+    ethics: "Bias, privacy, consent, misuse considerations; mitigation steps",
+  };
+  await emit({ type: "final", plan, selected: selected ?? null });
+  return plan;
+}
+


### PR DESCRIPTION
This PR wires Server-Sent Events for /api/runs/start and /api/runs/[id]/resume and introduces minimal agent/workflow scaffolding.\n\nWhat\n- Add ThemeFinderAgent (skeleton) emitting started/progress/candidates/suspend events (prep for Mastra .suspend())\n- Add research-plan workflow (draftPlanFromSelection) emitting started/progress/final\n- start route streams agent events; resume route streams workflow events and persists result when possible\n\nNotes\n- Persistence is best-effort; DB ops are optional and won’t throw.\n- Designed to swap internals to Mastra later with minimal API changes.\n- No external deps added; SSE uses ReadableStream.\n\nFollow-up\n- Replace skeleton with Mastra agents/workflows.\n- Hook UI to stream updates if not already.\n

Closes #8, Closes #9
Related to #13, #20
