### PR TITLE
fix/dev origin cookies zod

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,17 +5,14 @@ const nextConfig: NextConfig = {
     // Do not block builds on ESLint errors; surface via `bun run lint` instead
     ignoreDuringBuilds: true,
   },
-  experimental: {
-    // Prevent Turbopack from trying to bundle native/optional deps from Mastra
-    // and platform-specific esbuild packages referenced transitively.
-    serverComponentsExternalPackages: [
-      "mastra",
-      "esbuild",
-      "@esbuild/darwin-arm64",
-      "@esbuild/darwin-x64",
-      "@esbuild/linux-x64",
-    ],
-  },
+  // Next.js 15: use serverExternalPackages instead of experimental.serverComponentsExternalPackages
+  serverExternalPackages: [
+    "mastra",
+    "esbuild",
+    "@esbuild/darwin-arm64",
+    "@esbuild/darwin-x64",
+    "@esbuild/linux-x64",
+  ],
   webpack(config) {
     // Gracefully treat markdown files as raw source to avoid loader errors
     config.module.rules.push({

--- a/frontend/src/app/api/projects/route.ts
+++ b/frontend/src/app/api/projects/route.ts
@@ -4,7 +4,7 @@ export async function GET(req: Request) {
   const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
   if (!allowRate(`projects:get:${ip}`, 60, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429, headers: { "cache-control": "no-store" } });
   const { createRouteUserClient } = await import("@/lib/supabase/server-route");
-  const sbUser = createRouteUserClient();
+  const sbUser = await createRouteUserClient();
   if (!sbUser) return Response.json({ ok: false, error: "unauthorized" }, { status: 401, headers: { "cache-control": "no-store" } });
   const { data, error } = await sbUser.from("projects").select("id,title,domain,created_at").order("created_at", { ascending: false });
   if (error) return Response.json({ ok: false, error: error.message }, { status: 500, headers: { "cache-control": "no-store" } });
@@ -18,9 +18,10 @@ export async function POST(req: Request) {
   if (!allowRate(`projects:post:${ip}`, 20, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429 });
   // Origin allowlist
   const origin = req.headers.get("origin");
-  const selfOrigin = new URL(req.url).origin;
-  const allow = (process.env.APP_ALLOWED_ORIGINS || selfOrigin).split(",").map((s) => s.trim()).filter(Boolean);
-  if (origin && !allow.includes(origin)) return Response.json({ ok: false, error: "forbidden" }, { status: 403 });
+  const selfURL = new URL(req.url);
+  const allow = (process.env.APP_ALLOWED_ORIGINS || selfURL.origin).split(",").map((s) => s.trim()).filter(Boolean);
+  const allowed = !origin || allow.includes(origin) || (origin ? new URL(origin).host === selfURL.host : false);
+  if (!allowed) return Response.json({ ok: false, error: "forbidden" }, { status: 403 });
   const body = await req.json().catch(() => ({}));
   const { z } = await import("zod");
   const schema = z.object({ title: z.string().min(1).max(200), domain: z.string().optional() });
@@ -30,7 +31,7 @@ export async function POST(req: Request) {
   const domain: string | undefined = parsed.data.domain;
 
   const { createRouteUserClient } = await import("@/lib/supabase/server-route");
-  const sbUser = createRouteUserClient();
+  const sbUser = await createRouteUserClient();
   if (!sbUser) return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
 
   // owner_id assignment should be handled by RLS/trigger in Supabase

--- a/frontend/src/app/api/results/route.ts
+++ b/frontend/src/app/api/results/route.ts
@@ -3,7 +3,7 @@ export async function GET(req: Request) {
   const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
   if (!allowRate(`results:get:${ip}`, 60, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429, headers: { "cache-control": "no-store" } });
   const { createRouteUserClient } = await import("@/lib/supabase/server-route");
-  const sbUser = createRouteUserClient();
+  const sbUser = await createRouteUserClient();
   if (!sbUser) return Response.json({ ok: false, error: "unauthorized" }, { status: 401, headers: { "cache-control": "no-store" } });
 
   const url = new URL(req.url);

--- a/frontend/src/app/api/runs/start/route.ts
+++ b/frontend/src/app/api/runs/start/route.ts
@@ -3,12 +3,13 @@ import { createRouteUserClient } from "@/lib/supabase/server-route";
 
 export async function POST(req: Request) {
   const origin = req.headers.get("origin");
-  const selfOrigin = new URL(req.url).origin;
-  const allow = (process.env.APP_ALLOWED_ORIGINS || selfOrigin)
+  const selfURL = new URL(req.url);
+  const allow = (process.env.APP_ALLOWED_ORIGINS || selfURL.origin)
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
-  if (origin && !allow.includes(origin)) return new Response("forbidden", { status: 403, headers: { "cache-control": "no-store" } });
-  const sb = createRouteUserClient();
+  const allowed = !origin || allow.includes(origin) || (origin ? new URL(origin).host === selfURL.host : false);
+  if (!allowed) return new Response("forbidden", { status: 403, headers: { "cache-control": "no-store" } });
+  const sb = await createRouteUserClient();
   return postStart(req, { sb });
 }

--- a/frontend/src/lib/supabase/server-route.ts
+++ b/frontend/src/lib/supabase/server-route.ts
@@ -1,7 +1,7 @@
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 
-export function createRouteUserClient() {
-  return createRouteHandlerClient({ cookies });
+export async function createRouteUserClient() {
+  const store = await cookies();
+  return createRouteHandlerClient({ cookies: () => store });
 }
-

--- a/frontend/src/server/api/runs/start.ts
+++ b/frontend/src/server/api/runs/start.ts
@@ -9,8 +9,17 @@ export async function postStart(req: Request, ctx: Ctx = {}): Promise<Response> 
       kind: z.literal("theme"),
       input: z
         .object({
-          query: z.string().min(1).max(2000).optional(),
-          projectId: z.string().uuid().optional(),
+          // Treat empty strings as undefined to avoid validation noise
+          query: z
+            .preprocess((v) => (typeof v === "string" && v.trim().length === 0 ? undefined : v), z.string().min(1).max(2000))
+            .optional(),
+          // Accept null and coerce to undefined
+          projectId: z
+            .string()
+            .uuid()
+            .optional()
+            .nullable()
+            .transform((v) => (v ? v : undefined)),
           domain: z.string().optional(),
           keywords: z.string().optional(),
         })


### PR DESCRIPTION
- **docs(db): add migration-first workflow overview; chore(frontend): add supabase db scripts and type-gen script**
- **feat(runs): wire SSE for start/resume with agent/workflow skeletons\n\n- Add ThemeFinderAgent skeleton and events\n- Add research-plan workflow (draftPlanFromSelection)\n- Stream SSE for start and resume endpoints\n- Prepare for Mastra .suspend/.resume integration**
- **fix(resume): return JSON payload to match existing UI; keep streaming for start only**
- **chore(mastra): prepare dynamic workflow helpers; deps + build config\n\n- Add mastra dep and dynamic helper (not wired yet)\n- Install @supabase/auth-helpers-nextjs\n- Next build: ignore ESLint during build, fix route types\n- Ensure build passes locally**
- **fix(api,db): align API with DB schema**
- **feat(db,api): extend results schema with project_id/type/uri/meta_json and update API writes/reads**
- **chore(db): regenerate Supabase types after schema update**
- **feat(mastra): add theme workflow and wire /api/runs/start to use Mastra for candidate generation with suspend fallback**
- **feat(mastra): persist workflow run mapping and enable resume path; docs: add Mastra design/version notes in AGENTS.md**
- **feat(mastra): store workflow snapshots on suspend/resume; docs: update AGENTS.md storage section**
- **docs(tasks): sync checkboxes and roadmap status\n\n- 100: mark candidates persistence done\n- 103: mark schema/RLS/trigger done\n- Roadmap: set In Progress and add progress update (2025-08-13)**
- **feat(epic-101): Plan Editor UI with /api/plans and Export route for Markdown+CSL\n\n- Add GET/POST /api/plans (RLS-respecting)\n- Implement Plan editor page with ProjectPicker, load/save\n- Add POST /api/export/plan to serialize plan and save results (markdown/csl)\n- Export page to trigger export and preview outputs**
- **fix(dev): avoid Turbopack module-type error by externalizing mastra/esbuild in next.config and using eval(import) for mastra dynamic import**
- **fix(dev): allow same-host origins in API, await cookies() for Supabase route client, and relax start payload validation\n\n- Origin: accept 127.0.0.1/localhost if same host, or from APP_ALLOWED_ORIGINS\n- Supabase: await cookies() and pass stable store to createRouteHandlerClient; update all routes to await\n- Zod: accept null/empty projectId and trim/ignore empty query in /api/runs/start\n- Next 15: serverExternalPackages already set for mastra/esbuild in a prior commit**
