### PR TITLE
feature/epic 101 versioning export

### DIFF
--- a/frontend/src/app/api/export/plan/route.ts
+++ b/frontend/src/app/api/export/plan/route.ts
@@ -58,8 +58,19 @@ function planToMarkdown(p: any): string {
   return lines.join("\n");
 }
 
-function planToCSL(_p: any): any[] {
-  // Stub: empty bibliography list; fill via citation pipeline later
-  return [];
+function planToCSL(p: any): any[] {
+  // If plan contains citations array, map into minimal CSL JSON items
+  const cites = Array.isArray(p?.citations) ? p.citations : [];
+  return cites.map((c: any, idx: number) => ({
+    id: c.id || `ref-${idx + 1}`,
+    type: c.type || "article-journal",
+    title: c.title || "",
+    author: Array.isArray(c.author)
+      ? c.author.map((a: any) => ({ given: a.given || a.first || "", family: a.family || a.last || "" }))
+      : undefined,
+    issued: c.year ? { "date-parts": [[Number(c.year)]] } : undefined,
+    DOI: c.doi || undefined,
+    URL: c.url || undefined,
+    containerTitle: c.journal || undefined,
+  }));
 }
-

--- a/frontend/src/app/api/plans/history/route.ts
+++ b/frontend/src/app/api/plans/history/route.ts
@@ -1,0 +1,21 @@
+export async function GET(req: Request) {
+  const { allowRate } = await import("@/lib/utils/rate-limit");
+  const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
+  if (!allowRate(`plans:history:get:${ip}`, 60, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429, headers: { "cache-control": "no-store" } });
+  const { createRouteUserClient } = await import("@/lib/supabase/server-route");
+  const sbUser = await createRouteUserClient();
+  if (!sbUser) return Response.json({ ok: false, error: "unauthorized" }, { status: 401, headers: { "cache-control": "no-store" } });
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get("projectId");
+  const limit = Number(url.searchParams.get("limit") || 10);
+  if (!projectId) return Response.json({ ok: false, error: "missing_projectId" }, { status: 400, headers: { "cache-control": "no-store" } });
+  const { data, error } = await sbUser
+    .from("plans")
+    .select("id, project_id, title, status, created_at")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false })
+    .limit(Math.max(1, Math.min(limit, 50)));
+  if (error) return Response.json({ ok: false, error: error.message }, { status: 500, headers: { "cache-control": "no-store" } });
+  return Response.json({ ok: true, items: data || [] }, { headers: { "cache-control": "no-store" } });
+}
+

--- a/frontend/src/app/api/plans/restore/route.ts
+++ b/frontend/src/app/api/plans/restore/route.ts
@@ -1,0 +1,36 @@
+export async function POST(req: Request) {
+  const { allowRate } = await import("@/lib/utils/rate-limit");
+  const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
+  if (!allowRate(`plans:restore:post:${ip}`, 20, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429 });
+  const origin = req.headers.get("origin");
+  const self = new URL(req.url);
+  const allow = (process.env.APP_ALLOWED_ORIGINS || self.origin).split(",").map((s) => s.trim()).filter(Boolean);
+  const allowed = !origin || allow.includes(origin) || (origin ? new URL(origin).host === self.host : false);
+  if (!allowed) return Response.json({ ok: false, error: "forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const { z } = await import("zod");
+  const schema = z.object({ planId: z.string().uuid() });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return Response.json({ ok: false, error: "invalid_payload" }, { status: 400 });
+  const { planId } = parsed.data;
+
+  const { createRouteUserClient } = await import("@/lib/supabase/server-route");
+  const sbUser = await createRouteUserClient();
+  if (!sbUser) return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
+
+  // Load the original plan (RLS enforces ownership)
+  const { data: orig, error: selErr } = await sbUser.from("plans").select("id, project_id, title, status, content").eq("id", planId).single();
+  if (selErr) return Response.json({ ok: false, error: selErr.message }, { status: 404 });
+
+  // Insert a new version (copy content). Title/status can be carried or marked as draft.
+  const { data: inserted, error: insErr } = await sbUser
+    .from("plans")
+    .insert({ project_id: orig.project_id, title: orig.title, status: "draft", content: orig.content })
+    .select("id, project_id, title, status, created_at")
+    .single();
+  if (insErr) return Response.json({ ok: false, error: insErr.message }, { status: 500 });
+
+  return Response.json({ ok: true, restored: inserted }, { status: 201 });
+}
+


### PR DESCRIPTION
- **docs(db): add migration-first workflow overview; chore(frontend): add supabase db scripts and type-gen script**
- **feat(runs): wire SSE for start/resume with agent/workflow skeletons\n\n- Add ThemeFinderAgent skeleton and events\n- Add research-plan workflow (draftPlanFromSelection)\n- Stream SSE for start and resume endpoints\n- Prepare for Mastra .suspend/.resume integration**
- **fix(resume): return JSON payload to match existing UI; keep streaming for start only**
- **chore(mastra): prepare dynamic workflow helpers; deps + build config\n\n- Add mastra dep and dynamic helper (not wired yet)\n- Install @supabase/auth-helpers-nextjs\n- Next build: ignore ESLint during build, fix route types\n- Ensure build passes locally**
- **fix(api,db): align API with DB schema**
- **feat(db,api): extend results schema with project_id/type/uri/meta_json and update API writes/reads**
- **chore(db): regenerate Supabase types after schema update**
- **feat(mastra): add theme workflow and wire /api/runs/start to use Mastra for candidate generation with suspend fallback**
- **feat(mastra): persist workflow run mapping and enable resume path; docs: add Mastra design/version notes in AGENTS.md**
- **feat(mastra): store workflow snapshots on suspend/resume; docs: update AGENTS.md storage section**
- **docs(tasks): sync checkboxes and roadmap status\n\n- 100: mark candidates persistence done\n- 103: mark schema/RLS/trigger done\n- Roadmap: set In Progress and add progress update (2025-08-13)**
- **feat(epic-101): Plan Editor UI with /api/plans and Export route for Markdown+CSL\n\n- Add GET/POST /api/plans (RLS-respecting)\n- Implement Plan editor page with ProjectPicker, load/save\n- Add POST /api/export/plan to serialize plan and save results (markdown/csl)\n- Export page to trigger export and preview outputs**
- **fix(dev): avoid Turbopack module-type error by externalizing mastra/esbuild in next.config and using eval(import) for mastra dynamic import**
- **fix(dev): allow same-host origins in API, await cookies() for Supabase route client, and relax start payload validation\n\n- Origin: accept 127.0.0.1/localhost if same host, or from APP_ALLOWED_ORIGINS\n- Supabase: await cookies() and pass stable store to createRouteHandlerClient; update all routes to await\n- Zod: accept null/empty projectId and trim/ignore empty query in /api/runs/start\n- Next 15: serverExternalPackages already set for mastra/esbuild in a prior commit**
- **feat(epic-101): plan versioning (history + restore) and export enhancements\n\n- GET /api/plans/history, POST /api/plans/restore\n- Plan page: history list + restore action\n- Export: enrich Markdown template and map optional plan.citations -> CSL**
