### PR TITLE
docs: plan versioning semantics; no-store on POST

### DIFF
--- a/docs/plan-versioning.md
+++ b/docs/plan-versioning.md
@@ -1,0 +1,15 @@
+# Plan Versioning Semantics (EPIC-101)
+
+MVP acceptance:
+- Each save creates a new version (`plans.created_at` ordering), no in-place updates.
+- Restore creates a new draft copy derived from the selected version.
+- Latest version is returned by `GET /api/plans?projectId=...`.
+
+Implementation notes:
+- `POST /api/plans` inserts a new row with provided `title/status` and `content`.
+- `POST /api/plans/restore` clones `content` and sets `status = "draft"`.
+- `GET /api/plans/history` lists recent versions (id, title, status, created_at).
+
+Operational guidance:
+- Treat `status` as a label (draft/final/etc.). Promotion to final is future scope; MVP uses `draft`.
+- UI always shows latest; History supports Restore → new draft.

--- a/frontend/src/app/api/plans/route.ts
+++ b/frontend/src/app/api/plans/route.ts
@@ -54,5 +54,5 @@ export async function POST(req: Request) {
     .select("id, project_id, title, status, content, created_at")
     .single();
   if (error) return Response.json({ ok: false, error: error.message }, { status: 500 });
-  return Response.json({ ok: true, item: data }, { status: 201 });
+  return Response.json({ ok: true, item: data }, { status: 201, headers: { "cache-control": "no-store" } });
 }


### PR DESCRIPTION
Adds documentation for plan versioning semantics and sets no-store on POST response to avoid caching discrepancies.\n\nCloses #16