### PR TITLE
task: add EPIC-107/108/109 docs (LLM, RAG, eval)

### DIFF
--- a/task/107-epic-llm-integration-and-prompting.md
+++ b/task/107-epic-llm-integration-and-prompting.md
@@ -1,0 +1,28 @@
+# 107: LLM Integration & Prompting (from mock → real agents)
+
+- Status: Planned
+- Owner: TBD
+- Goal: Replace mock candidate/plan generation with real LLM-backed agents (Mastra), with prompt library, schema validation, and safe fallbacks.
+
+## Milestones
+1) Provider Abstraction: server-side LLM client (OpenAI/Google) + env wiring + rate limits
+2) Prompt Library: reusable templates for candidates/plan; zod schemas for outputs
+3) Mastra Steps: replace `find-candidates` and `draft-plan` with LLM calls; emit progress; persist results
+4) Fallbacks & Flags: `USE_REAL_LLM` feature flag; JSON-parse fallback to stub; error handling
+5) Telemetry: capture tokens/costs/timings into `tool_invocations`
+
+## Deliverables
+- `lib/llm/provider.ts` (REST-based, no SDK dependency initially)
+- `agents/prompts/{candidates,plan}.ts` templates + docs (`docs/prompts/*.md`)
+- Updated `workflows/mastra/theme.ts` using provider + prompts; strict zod parsing
+- Feature flags via env; runtime-safe fallbacks
+- Minimal docs: usage, keys, limits
+
+## Acceptance Criteria
+- Theme Explorer produces LLM-derived candidates when `USE_REAL_LLM=1`
+- Resume produces LLM-derived plan JSON valid against schema; version recorded in `plans`
+- Errors do not crash flows; stub fallback works; logs stored
+
+## Notes
+- Streaming can be added later; start non-streaming for simplicity
+- Consider @vercel/ai later; start with REST to reduce deps

--- a/task/108-epic-scholarly-and-rag-enrichment.md
+++ b/task/108-epic-scholarly-and-rag-enrichment.md
@@ -1,0 +1,16 @@
+# 108: Scholarly Search & RAG Enrichment
+
+- Status: Planned
+- Owner: TBD
+- Goal: Provide optional retrieval context (arXiv/Semantic Scholar + pgvector) to ground LLM outputs and collect citations.
+
+## Milestones
+1) Scholarly Clients: arXiv + Semantic Scholar minimal query wrappers + normalizers
+2) RAG Basics: chunking, embedding, store in `chunks` with pgvector; keyword query → vector search
+3) Tooling: `rag.search` tool to feed snippets into prompts; track provenance
+4) Citations: map retrieved metadata to CSL and include in plan export
+
+## Acceptance Criteria
+- `rag.search` returns top-k snippets with titles/urls
+- Plan draft can include citations when RAG used
+- Export includes References and CSL items

--- a/task/109-epic-evaluation-and-observability.md
+++ b/task/109-epic-evaluation-and-observability.md
@@ -1,0 +1,16 @@
+# 109: Evaluation & Observability
+
+- Status: Planned
+- Owner: TBD
+- Goal: Establish a lightweight eval loop and runtime observability for prompt/parameter tuning.
+
+## Milestones
+1) Eval Harness: golden cases + metrics (schema pass rate, section completeness, length bands)
+2) Prompt Experiments: prompt variants tracked in docs; A/B config and diff report
+3) Telemetry: token usage, latency, cost estimates per run; UI surface for recent runs/logs (#29)
+4) Safety: token caps, truncation policy, basic content policy checks
+
+## Acceptance Criteria
+- `scripts/eval` shows a pass/fail summary on golden set
+- PRs can link to eval summary outputs
+- `tool_invocations` records tokens/latency; basic dashboard exists (or CSV export)


### PR DESCRIPTION
Adds deep plan docs to move from mock → real LLM agents.
- 107 LLM Integration & Prompting
- 108 Scholarly Search & RAG Enrichment
- 109 Evaluation & Observability
 
Related issues: #70 #71 #72 #73 #74 #75 #76 #77 #78 #79