### PR TITLE
107-2: AI SDK wiring + OpenRouter, LLM debug visibility, cookies() fix, resume LLM meta, parsing and telemetry

### DIFF
--- a/frontend/src/lib/llm/json.ts
+++ b/frontend/src/lib/llm/json.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+// Schemas
+export const zCandidateItem = z.object({
+  id: z.string().min(1).max(40).optional().transform((v) => v ?? ""),
+  title: z.string().min(1).max(500),
+  novelty: z.number().min(0).max(1).optional().transform((v) => (typeof v === "number" && isFinite(v) ? v : 0.5)),
+  risk: z.number().min(0).max(1).optional().transform((v) => (typeof v === "number" && isFinite(v) ? v : 0.5)),
+});
+export const zCandidatesJSON = z.object({ candidates: z.array(zCandidateItem).min(1) });
+
+export const zPlanJSON = z.object({
+  title: z.string().min(1),
+  rq: z.string().default(""),
+  hypothesis: z.string().default(""),
+  data: z.string().default(""),
+  methods: z.string().default(""),
+  identification: z.string().default(""),
+  validation: z.string().default(""),
+  ethics: z.string().default(""),
+});
+
+// Tolerant JSON extraction: fenced blocks → first JSON object/array → direct parse
+export function extractJsonLike(text: string): any | undefined {
+  if (!text || typeof text !== "string") return undefined;
+  // Try direct
+  try { return JSON.parse(text); } catch {}
+  // Try fenced code blocks ```json ... ``` or ``` ... ```
+  const fence = /```(?:json)?\n([\s\S]*?)```/i.exec(text);
+  if (fence && fence[1]) {
+    try { return JSON.parse(fence[1]); } catch {}
+  }
+  // Try to locate first { ... } or [ ... ] conservatively
+  const firstObj = text.indexOf("{");
+  const lastObj = text.lastIndexOf("}");
+  if (firstObj !== -1 && lastObj !== -1 && lastObj > firstObj) {
+    const slice = text.slice(firstObj, lastObj + 1);
+    try { return JSON.parse(slice); } catch {}
+  }
+  const firstArr = text.indexOf("[");
+  const lastArr = text.lastIndexOf("]");
+  if (firstArr !== -1 && lastArr !== -1 && lastArr > firstArr) {
+    const slice = text.slice(firstArr, lastArr + 1);
+    try { return JSON.parse(slice); } catch {}
+  }
+  return undefined;
+}
+
+export function parseWithSchema<T>(text: string, schema: z.ZodSchema<T>): T | undefined {
+  const raw = extractJsonLike(text);
+  if (!raw) return undefined;
+  const r = schema.safeParse(raw);
+  if (r.success) return r.data;
+  return undefined;
+}
+
+export function parseCandidatesLLM(text: string): z.infer<typeof zCandidatesJSON> | undefined {
+  return parseWithSchema(text, zCandidatesJSON);
+}
+
+export function parsePlanLLM(text: string): z.infer<typeof zPlanJSON> | undefined {
+  return parseWithSchema(text, zPlanJSON);
+}
+

--- a/frontend/src/server/api/runs/resume.ts
+++ b/frontend/src/server/api/runs/resume.ts
@@ -40,6 +40,17 @@ export async function postResume(req: Request, params: { id: string }, ctx: Ctx 
           const output = (resumed as any)?.steps?.["draft-plan"]?.output ?? null;
           plan = output?.plan ?? null;
           llm = output?._llm ?? null;
+          if (sb && llm) {
+            try {
+              await sb.from("tool_invocations").insert({
+                run_id: id,
+                tool: "llm",
+                args_json: { step: "draft-plan" },
+                result_meta: { path: llm.path, model: llm.model },
+                latency_ms: llm.latencyMs ?? null,
+              });
+            } catch {}
+          }
           // Store latest snapshot for debugging/audit
           try {
             await sb

--- a/frontend/src/server/api/runs/start.ts
+++ b/frontend/src/server/api/runs/start.ts
@@ -2,6 +2,7 @@ import { ThemeFinderAgent, type ThemeFinderInput } from "@/agents/theme-finder";
 import { startThemeMastra } from "@/workflows/mastra/theme";
 import { createProvider } from "@/lib/llm/provider";
 import { buildCandidateMessages, type CandidatesJSON } from "@/agents/prompts/candidates";
+import { parseCandidatesLLM } from "@/lib/llm/json";
 
 type Ctx = { sb?: any };
 export async function postStart(req: Request, ctx: Ctx = {}): Promise<Response> {
@@ -125,7 +126,7 @@ export async function postStart(req: Request, ctx: Ctx = {}): Promise<Response> 
             keywords: (input as any)?.keywords,
           });
           const res = await provider.chat<CandidatesJSON>(msgs as any, { json: true, maxTokens: 700 });
-          const parsed = (res.parsed as CandidatesJSON | undefined) ?? JSON.parse(res.rawText);
+          const parsed = (res.parsed as CandidatesJSON | undefined) ?? parseCandidatesLLM(res.rawText);
           const items = Array.isArray(parsed?.candidates) ? parsed!.candidates.slice(0, 3).map((c, i) => ({
             id: c.id || `t${i + 1}`,
             title: String(c.title || "Untitled theme"),

--- a/frontend/src/workflows/mastra/theme.ts
+++ b/frontend/src/workflows/mastra/theme.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { createProvider } from "@/lib/llm/provider";
 import { buildCandidateMessages, type CandidatesJSON } from "@/agents/prompts/candidates";
 import { buildPlanMessages, type PlanJSON } from "@/agents/prompts/plan";
+import { parseCandidatesLLM, parsePlanLLM } from "@/lib/llm/json";
 
 export type ThemeStartInput = {
   query?: string;
@@ -47,7 +48,7 @@ export async function startThemeMastra(input: ThemeStartInput) {
         keywords: inputData?.keywords,
       });
       const res = await provider.chat<CandidatesJSON>(msgs as any, { json: true, maxTokens: 700 });
-      const parsed = (res.parsed as CandidatesJSON | undefined) ?? safeParseCandidates(res.rawText);
+      const parsed = (res.parsed as CandidatesJSON | undefined) ?? parseCandidatesLLM(res.rawText);
       if (!parsed?.candidates || !Array.isArray(parsed.candidates) || parsed.candidates.length === 0) {
         throw new Error("llm_candidates_parse_failed");
       }
@@ -109,7 +110,7 @@ export async function startThemeMastra(input: ThemeStartInput) {
       const provider = createProvider();
       const msgs = buildPlanMessages({ title });
       const res = await provider.chat<PlanJSON>(msgs as any, { json: true, maxTokens: 900 });
-      const parsed = (res.parsed as PlanJSON | undefined) ?? safeParsePlan(res.rawText, title);
+      const parsed = (res.parsed as PlanJSON | undefined) ?? parsePlanLLM(res.rawText);
       if (!parsed) throw new Error("llm_plan_parse_failed");
       return { plan: parsed, _llm: { path: res.path, model: res.model, latencyMs: res.latencyMs } };
     },
@@ -179,7 +180,7 @@ export async function resumeThemeMastraById(runId: string, resumeData: any) {
       const provider = createProvider();
       const msgs = buildPlanMessages({ title });
       const res = await provider.chat<PlanJSON>(msgs as any, { json: true, maxTokens: 900 });
-      const parsed = (res.parsed as PlanJSON | undefined) ?? safeParsePlan(res.rawText, title);
+      const parsed = (res.parsed as PlanJSON | undefined) ?? parsePlanLLM(res.rawText);
       if (!parsed) throw new Error("llm_plan_parse_failed");
       return { plan: parsed, _llm: { path: res.path, model: res.model, latencyMs: res.latencyMs } };
     },
@@ -193,22 +194,3 @@ export async function resumeThemeMastraById(runId: string, resumeData: any) {
 }
 
 function clamp01(n: number) { return isFinite(n) ? Math.max(0, Math.min(1, n)) : 0.5; }
-function safeParseCandidates(text: string): CandidatesJSON | undefined {
-  try { return JSON.parse(text) as CandidatesJSON; } catch { return undefined; }
-}
-function safeParsePlan(text: string, title: string): PlanJSON | undefined {
-  try {
-    const obj = JSON.parse(text) as any;
-    if (!obj || typeof obj !== "object") return undefined;
-    return {
-      title: String(obj.title || title || "Untitled"),
-      rq: String(obj.rq || ""),
-      hypothesis: String(obj.hypothesis || ""),
-      data: String(obj.data || ""),
-      methods: String(obj.methods || ""),
-      identification: String(obj.identification || ""),
-      validation: String(obj.validation || ""),
-      ethics: String(obj.ethics || ""),
-    };
-  } catch { return undefined; }
-}


### PR DESCRIPTION
Improvements for EPIC-107 (LLM integration):\n\n- Wire AI SDK with OpenRouter; REST fallback with explicit path reporting\n- Add USE_LLM_DEBUG to surface [LLM] path/model/latency and SSE progress\n- Fix Next.js cookies() warning on /api/projects by awaiting cookies() in route client\n- Expose LLM meta on resume (plan step) and log in Theme/Workspace\n- Add tolerant JSON parsing with zod schemas for candidates/plan (107-4)\n- Record tool_invocations for LLM calls with path/model/latency (107-7)\n\nValidation:\n- Set USE_REAL_LLM=1, USE_AI_SDK=1 (opt), USE_LLM_DEBUG=1 and OpenRouter env\n- Start a run from /theme or /workspace, see llm_path progress\n- On resume, logs should show llm_path for draft-plan\n- /api/projects no longer warns about cookies()\n\nRelates: #107\nCloses: #98