### PR TITLE
107-3: Prompt library for candidates/plan + docs

### DIFF
--- a/docs/prompts/candidates.md
+++ b/docs/prompts/candidates.md
@@ -1,0 +1,15 @@
+# Candidates Prompt (107-3)
+
+- Purpose: Generate exactly 3 concise, distinct research theme candidates.
+- Output schema: `{ "candidates": [{ "id": "t1", "title": "...", "novelty": 0..1, "risk": 0..1 }, ...] }`
+- Constraints:
+  - `id`: `t1`, `t2`, `t3` (stable short ids)
+  - `title`: one-line, specific, testable
+  - `novelty`, `risk`: numeric [0,1]
+  - JSON only; no prose/markdown
+- Hints: include domain, keywords, and user query/context when provided
+
+References
+- Source: `frontend/src/agents/prompts/candidates.ts`
+- Parser: `frontend/src/lib/llm/json.ts` (`zCandidatesJSON`)
+

--- a/docs/prompts/plan.md
+++ b/docs/prompts/plan.md
@@ -1,0 +1,12 @@
+## Plan Prompt (107-3)
+
+- Purpose: Draft a structured research plan from a selected theme title.
+- Output schema (all values strings):
+  `{ title, rq, hypothesis, data, methods, identification, validation, ethics }`
+- Guidance included in system message to improve structure and coverage.
+- JSON only; no prose/markdown.
+
+References
+- Source: `frontend/src/agents/prompts/plan.ts`
+- Parser: `frontend/src/lib/llm/json.ts` (`zPlanJSON`)
+

--- a/frontend/src/agents/prompts/candidates.ts
+++ b/frontend/src/agents/prompts/candidates.ts
@@ -1,6 +1,33 @@
 export function buildCandidateMessages(input: { query?: string; domain?: string; keywords?: string }) {
-  const system = `You are a research theme exploration assistant. Produce 3 concise theme candidates as JSON with fields: id (short id), title (one line), novelty (0..1), risk (0..1).`;
-  const user = `Domain: ${input.domain || ""}\nQuery: ${input.query || ""}\nKeywords: ${input.keywords || ""}\n\nReturn ONLY a JSON array named candidates, like: {"candidates":[{"id":"t1","title":"...","novelty":0.7,"risk":0.3}, ...]}`;
+  const system = [
+    "You are a research theme exploration assistant.",
+    "Your task: propose exactly 3 concise, distinct research theme candidates.",
+    "Output strictly in JSON with the following schema:",
+    "{\"candidates\":[{\"id\":\"t1\",\"title\":\"...\",\"novelty\":0.7,\"risk\":0.3},{...},{...}]}",
+    "Constraints:",
+    "- id: short stable id (t1,t2,t3)",
+    "- title: one-line, specific and testable (no fluff)",
+    "- novelty, risk: numbers in [0,1]",
+    "- No prose, no markdown, no commentary — JSON only.",
+  ].join("\n");
+
+  const domainHint = input.domain
+    ? `Focus domain: ${input.domain}. Prefer themes aligned with this domain.`
+    : "";
+  const keywordHint = input.keywords
+    ? `Consider keywords: ${input.keywords}.`
+    : "";
+  const queryHint = input.query ? `User query/context: ${input.query}` : "";
+
+  const user = [
+    domainHint,
+    keywordHint,
+    queryHint,
+    "Return only JSON matching the schema above.",
+    "Example:",
+    '{"candidates":[{"id":"t1","title":"Impact of LLM adoption on SME productivity","novelty":0.7,"risk":0.3},{"id":"t2","title":"Stablecoin shocks and DeFi liquidity","novelty":0.8,"risk":0.5},{"id":"t3","title":"RLHF data leakage in academic benchmarks","novelty":0.6,"risk":0.4}]}'
+  ].filter(Boolean).join("\n\n");
+
   return [
     { role: "system", content: system },
     { role: "user", content: user },
@@ -9,4 +36,3 @@ export function buildCandidateMessages(input: { query?: string; domain?: string;
 
 export type CandidateItem = { id: string; title: string; novelty: number; risk: number };
 export type CandidatesJSON = { candidates: CandidateItem[] };
-

--- a/frontend/src/agents/prompts/plan.ts
+++ b/frontend/src/agents/prompts/plan.ts
@@ -1,6 +1,26 @@
 export function buildPlanMessages(input: { title: string }) {
-  const system = `You are a research planning assistant. Produce a structured research plan as JSON with fields: title, rq, hypothesis, data, methods, identification, validation, ethics (all strings).`;
-  const user = `Selected Theme Title: ${input.title}\n\nReturn ONLY JSON object with the keys specified.`;
+  const system = [
+    "You are a research planning assistant.",
+    "Produce a structured research plan in strict JSON with keys:",
+    "{title, rq, hypothesis, data, methods, identification, validation, ethics}",
+    "All values are concise strings. No markdown, no commentary, JSON only.",
+    "Guidance:",
+    "- rq: a crisp, testable research question",
+    "- hypothesis: falsifiable statement",
+    "- data: concrete sources/datasets",
+    "- methods: econometrics/ML/experimental methods as applicable",
+    "- identification: assumptions, threats, instruments/design",
+    "- validation: evaluation, robustness, sensitivity",
+    "- ethics: privacy, bias, consent, misuse mitigation",
+  ].join("\n");
+
+  const user = [
+    `Selected Theme Title: ${input.title}`,
+    "Return ONLY the JSON object with the keys specified.",
+    "Example:",
+    '{"title":"Impact of LLM adoption on SME productivity","rq":"Does LLM adoption increase SME productivity?","hypothesis":"SMEs adopting LLMs achieve measurable productivity gains vs. matched controls.","data":"Firm-level productivity metrics, adoption logs, survey panels","methods":"Difference-in-differences; matching; event study; robustness checks","identification":"Parallel trends; instrument: staged rollout; placebo tests","validation":"Holdout validation; sensitivity analysis; external benchmarks","ethics":"Data privacy; consent; bias mitigation; secure storage"}'
+  ].join("\n\n");
+
   return [
     { role: "system", content: system },
     { role: "user", content: user },
@@ -17,4 +37,3 @@ export type PlanJSON = {
   validation: string;
   ethics: string;
 };
-

--- a/task/107-epic-llm-integration-and-prompting.md
+++ b/task/107-epic-llm-integration-and-prompting.md
@@ -31,7 +31,7 @@
 - [ ] Env & Flags: add `USE_REAL_LLM`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` to `.env.local` and config docs
 - [ ] Provider Interface: design `LlmProvider` interface (send JSON, receive text/JSON), model options, token caps
 - [ ] AI SDK Wiring: add minimal `@vercel/ai` server usage for chat/JSON; keep REST fallback path
-- [ ] Prompt Library: create `agents/prompts/{candidates,plan}.ts` with inputs, system prompts, few-shot examples
+- [x] Prompt Library: create `agents/prompts/{candidates,plan}.ts` with inputs, system prompts, few-shot examples
 - [ ] Schemas: define zod schemas for `Candidate`, `Plan`, `PlanSection`; strict parsing + coercion helpers
 - [ ] Mastra Step: implement `find-candidates` with provider + prompts; emit incremental progress/logs
 - [ ] Mastra Step: implement `draft-plan` (+ resume) with provider + schema validation; persist `results`/`plans`


### PR DESCRIPTION
Implements 107-3 (Prompt Library):\n\n- Enrich candidates prompt: enforce strict JSON schema, 3 items, domain/keyword/query hints, example\n- Enrich plan prompt: strict JSON schema, guidance bullets, example\n- Docs: docs/prompts/{candidates,plan}.md with schema/usage references\n- Checklist: mark 107-3 Prompt Library as completed in task\n\nRelates: #107