### PR TITLE
108-1/108-4/109-3: Scholarly clients, citation suggest API + export enrichment, telemetry export

### DIFF
--- a/frontend/src/app/api/citations/suggest/route.ts
+++ b/frontend/src/app/api/citations/suggest/route.ts
@@ -1,0 +1,41 @@
+export async function POST(req: Request) {
+  const { allowRate } = await import("@/lib/utils/rate-limit");
+  const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
+  if (!allowRate(`citations:suggest:${ip}`, 10, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429 });
+
+  const origin = req.headers.get("origin");
+  const self = new URL(req.url);
+  const allow = (process.env.APP_ALLOWED_ORIGINS || self.origin).split(",").map((s) => s.trim()).filter(Boolean);
+  const allowed = !origin || allow.includes(origin) || (origin ? new URL(origin).host === self.host : false);
+  if (!allowed) return Response.json({ ok: false, error: "forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const { z } = await import("zod");
+  const schema = z.object({ projectId: z.string().uuid().optional(), title: z.string().optional(), rq: z.string().optional(), keywords: z.string().optional(), limit: z.number().int().min(1).max(10).optional() });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return Response.json({ ok: false, error: "invalid_payload" }, { status: 400 });
+  const { projectId, title, rq, keywords, limit } = parsed.data as any;
+
+  // Auth via user (RLS based on project-owned endpoints if later used). No DB writes here.
+  const { supabaseUserFromRequest } = await import("@/lib/supabase/user-server");
+  const headerClient = supabaseUserFromRequest(req);
+  const { createRouteUserClient } = await import("@/lib/supabase/server-route");
+  const cookieClient = await createRouteUserClient();
+  const sbUser = headerClient || cookieClient;
+  if (!sbUser) return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
+
+  const qParts = [title, rq, keywords].filter((s) => typeof s === "string" && s.trim().length > 0) as string[];
+  const query = qParts.join(" ").trim();
+  if (!query) return Response.json({ ok: true, items: [] }, { headers: { "cache-control": "no-store" } });
+  const { searchSemanticScholar } = await import("@/lib/scholarly/semantic-scholar");
+  const { searchArxiv } = await import("@/lib/scholarly/arxiv");
+  let items: any[] = [];
+  try {
+    items = await searchSemanticScholar({ query, limit: limit ?? 5 });
+  } catch { items = []; }
+  if (items.length === 0) {
+    try { items = await searchArxiv(query, limit ?? 5); } catch { items = []; }
+  }
+  return Response.json({ ok: true, items }, { headers: { "cache-control": "no-store" } });
+}
+

--- a/frontend/src/app/api/metrics/tool-invocations/csv/route.ts
+++ b/frontend/src/app/api/metrics/tool-invocations/csv/route.ts
@@ -1,0 +1,54 @@
+function toCsvRow(vals: any[]): string {
+  return vals
+    .map((v) => {
+      const s = v == null ? "" : String(v);
+      return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+    })
+    .join(",");
+}
+
+export async function GET(req: Request) {
+  const { allowRate } = await import("@/lib/utils/rate-limit");
+  const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
+  if (!allowRate(`metrics:toolinv:csv:${ip}`, 10, 60_000)) return new Response("rate_limited", { status: 429 });
+
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get("projectId");
+  const limit = Math.max(1, Math.min(1000, Number(url.searchParams.get("limit") || 500)));
+
+  // Auth as user (RLS guards rows via runs.project_id ownership)
+  const { supabaseUserFromRequest } = await import("@/lib/supabase/user-server");
+  const headerClient = supabaseUserFromRequest(req);
+  const { createRouteUserClient } = await import("@/lib/supabase/server-route");
+  const cookieClient = await createRouteUserClient();
+  const sb = headerClient || cookieClient;
+  if (!sb) return new Response("unauthorized", { status: 401 });
+
+  let runIds: string[] | null = null;
+  if (projectId) {
+    const { data: runs } = await sb.from("runs").select("id").eq("project_id", projectId).order("started_at", { ascending: false }).limit(2000);
+    runIds = (runs || []).map((r: any) => r.id);
+    if (runIds.length === 0) return new Response("run_id,tool,created_at,cost_usd\n", { headers: { "content-type": "text/csv" } });
+  }
+  let q = sb.from("tool_invocations").select("run_id, tool, args, result, cost_usd, created_at").order("created_at", { ascending: false }).limit(limit);
+  if (runIds) q = (q as any).in("run_id", runIds);
+  const { data, error } = await q;
+  if (error) return new Response(error.message, { status: 500 });
+
+  const header = ["run_id", "tool", "created_at", "cost_usd", "args_json", "result_json"];
+  const rows = [header.join(",")];
+  for (const r of data || []) {
+    rows.push(
+      toCsvRow([
+        r.run_id,
+        r.tool,
+        r.created_at,
+        r.cost_usd ?? "",
+        r.args ? JSON.stringify(r.args) : "",
+        r.result ? JSON.stringify(r.result) : "",
+      ])
+    );
+  }
+  return new Response(rows.join("\n") + "\n", { headers: { "content-type": "text/csv", "cache-control": "no-store" } });
+}
+

--- a/frontend/src/app/api/metrics/tool-invocations/json/route.ts
+++ b/frontend/src/app/api/metrics/tool-invocations/json/route.ts
@@ -1,0 +1,31 @@
+export async function GET(req: Request) {
+  const { allowRate } = await import("@/lib/utils/rate-limit");
+  const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown").toString();
+  if (!allowRate(`metrics:toolinv:json:${ip}`, 10, 60_000)) return Response.json({ ok: false, error: "rate_limited" }, { status: 429 });
+
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get("projectId");
+  const limit = Math.max(1, Math.min(1000, Number(url.searchParams.get("limit") || 500)));
+
+  // Auth as user (RLS guards rows via runs.project_id ownership)
+  const { supabaseUserFromRequest } = await import("@/lib/supabase/user-server");
+  const headerClient = supabaseUserFromRequest(req);
+  const { createRouteUserClient } = await import("@/lib/supabase/server-route");
+  const cookieClient = await createRouteUserClient();
+  const sb = headerClient || cookieClient;
+  if (!sb) return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
+
+  // Filter by project via run ids (RLS still applies)
+  let runIds: string[] | null = null;
+  if (projectId) {
+    const { data: runs } = await sb.from("runs").select("id").eq("project_id", projectId).order("started_at", { ascending: false }).limit(2000);
+    runIds = (runs || []).map((r: any) => r.id);
+    if (runIds.length === 0) return Response.json({ ok: true, items: [] }, { headers: { "cache-control": "no-store" } });
+  }
+  let q = sb.from("tool_invocations").select("run_id, tool, args, result, cost_usd, created_at").order("created_at", { ascending: false }).limit(limit);
+  if (runIds) q = (q as any).in("run_id", runIds);
+  const { data, error } = await q;
+  if (error) return Response.json({ ok: false, error: error.message }, { status: 500 });
+  return Response.json({ ok: true, items: data || [] }, { headers: { "cache-control": "no-store" } });
+}
+

--- a/frontend/src/lib/scholarly/arxiv.ts
+++ b/frontend/src/lib/scholarly/arxiv.ts
@@ -1,0 +1,33 @@
+// Minimal arXiv client (108-1)
+// API: http://export.arxiv.org/api/query?search_query=all:query&start=0&max_results=5
+
+import type { CSLItem } from "./semantic-scholar";
+
+export async function searchArxiv(query: string, limit = 5): Promise<CSLItem[]> {
+  const q = (query || "").trim();
+  if (!q) return [];
+  const url = `http://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(q)}&start=0&max_results=${Math.max(1, Math.min(10, limit))}`;
+  const resp = await fetch(url, { headers: { accept: "application/atom+xml" } });
+  if (!resp.ok) return [];
+  const text = await resp.text();
+  // Very lightweight parsing for title, link, authors, published year
+  const entries = text.split("<entry>").slice(1);
+  const items: CSLItem[] = [];
+  for (const e of entries) {
+    const title = (e.match(/<title>([\s\S]*?)<\/title>/)?.[1] || "").trim().replace(/\s+/g, " ");
+    const link = e.match(/<link[^>]*href=\"([^\"]+)\"[^>]*rel=\"alternate\"/i)?.[1] || e.match(/<id>([^<]+)<\/id>/)?.[1] || undefined;
+    const published = e.match(/<published>(\d{4})-\d{2}-\d{2}/)?.[1];
+    const authors = Array.from(e.matchAll(/<name>([^<]+)<\/name>/g)).map((m) => m[1]);
+    items.push({
+      id: link || undefined,
+      type: "article-journal",
+      title: title || undefined,
+      author: authors.map((n) => ({ given: n.split(" ")[0] || "", family: n.split(" ").slice(1).join(" ") || "" })),
+      issued: published ? { "date-parts": [[Number(published)]] } : undefined,
+      URL: link,
+      containerTitle: "arXiv",
+    });
+  }
+  return items;
+}
+

--- a/frontend/src/lib/scholarly/semantic-scholar.ts
+++ b/frontend/src/lib/scholarly/semantic-scholar.ts
@@ -1,0 +1,44 @@
+// Minimal Semantic Scholar client (108-1)
+// Docs: https://api.semanticscholar.org/api-docs/
+
+export type ScholarlyQuery = { query: string; limit?: number };
+export type CSLItem = {
+  id?: string;
+  type?: string;
+  title?: string;
+  author?: { given?: string; family?: string }[];
+  issued?: { "date-parts": number[][] };
+  DOI?: string;
+  URL?: string;
+  containerTitle?: string;
+};
+
+export async function searchSemanticScholar(q: ScholarlyQuery): Promise<CSLItem[]> {
+  const query = (q.query || "").trim();
+  if (!query) return [];
+  const key = process.env.SEMANTIC_SCHOLAR_API_KEY;
+  const limit = Math.max(1, Math.min(10, q.limit ?? 5));
+  const url = new URL("https://api.semanticscholar.org/graph/v1/paper/search");
+  url.searchParams.set("query", query);
+  url.searchParams.set("limit", String(limit));
+  url.searchParams.set("fields", "title,year,authors,url,externalIds,venue");
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (key) headers["x-api-key"] = key;
+  const resp = await fetch(url.toString(), { headers });
+  if (!resp.ok) return [];
+  const data: any = await resp.json().catch(() => ({}));
+  const papers: any[] = Array.isArray(data?.data) ? data.data : [];
+  return papers.map((p: any, i: number): CSLItem => ({
+    id: p?.paperId || p?.externalIds?.DOI || `s2-${i + 1}`,
+    type: "article-journal",
+    title: p?.title || undefined,
+    author: Array.isArray(p?.authors)
+      ? p.authors.map((a: any) => ({ given: a?.name?.split(" ")?.[0] || "", family: a?.name?.split(" ")?.slice(1).join(" ") || "" }))
+      : undefined,
+    issued: p?.year ? { "date-parts": [[Number(p.year)]] } : undefined,
+    DOI: p?.externalIds?.DOI || undefined,
+    URL: p?.url || undefined,
+    containerTitle: p?.venue || undefined,
+  }));
+}
+


### PR DESCRIPTION
Implements three items with minimal, functional scope:

108-1 Scholarly clients
- : paper search (title/year/authors/DOI/url)
- : arXiv feed search (title/authors/year/url)

108-4 Citations wiring
- : suggest CSL-like items from title/rq/keywords (S2 → arXiv fallback)
- : if plan has no citations, enrich on-the-fly using suggestors (no persistence)

109-3 Telemetry export
-  and : filter by projectId; RLS via user client; CSV includes args/result JSON columns
 
Notes
- No UI changes; fully API/Lib.
- Respects RLS; metrics filtered via runs(project_id).
- Rate limited via allowRate.
Relates: #108, #109